### PR TITLE
SSL_client_hello_get1_extensions_present(): Check for 0 before calling malloc

### DIFF
--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -5140,6 +5140,9 @@ int SSL_client_hello_get1_extensions_present(SSL *s, int **out, size_t *outlen)
         if (ext->present)
             num++;
     }
+    if (num == 0) {
+        return 0;
+    }
     if ((present = OPENSSL_malloc(sizeof(*present) * num)) == NULL) {
         SSLerr(SSL_F_SSL_CLIENT_HELLO_GET1_EXTENSIONS_PRESENT,
                ERR_R_MALLOC_FAILURE);


### PR DESCRIPTION
SSL_client_hello_get1_extensions_present will return MALLOC_FAILURE for client hellos without extensions.

In our production, the server is running a plugin which calls SSL_client_hello_get1_extensions_present(). Some load balancers sending SSLv2 client hello with no extensions won't see handshake finished/response. After we disabled SSLv2 client hello, the problem goes away. However, looking into the code for SSL_client_hello_get1_extensions_present(), it didn't check whether the number of bytes is valid before calling malloc function and led to unsuccessful handshakes for empty extensions.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
